### PR TITLE
Only update sockets in the first read

### DIFF
--- a/core/Session.js
+++ b/core/Session.js
@@ -138,6 +138,7 @@ class Session extends Object {
                     .on(CLOSE, onClose)
                     .on(ERROR, onClose)
             );
+            this._updated = true;
         }
     }
 


### PR DESCRIPTION
This fixes a problem where handling long responses causes the sockets to be re-created multiple times.