### PR TITLE
Fix URL parsing

### DIFF
--- a/core/getConnectionOptions.js
+++ b/core/getConnectionOptions.js
@@ -13,7 +13,7 @@ function getAddressAndPortFromString(ipStringWithPort) {
     }
 
     let [protocol, host, port] = targetHost.split(STRINGS.SEPARATOR);
-    if (protocol.indexOf(HTTP) === -1) {
+    if (protocol.indexOf('://') === -1) {
         port = host;
         host = protocol;
         protocol = (port && parseInt(port) === HTTPS_PORT)


### PR DESCRIPTION
Fix parsing of URLs containing `http` in the domain name.

Reproduction: `https_proxy=127.0.0.1:8080 curl https://httpbin.org`

```
### 2022-07-15T08:34:45.686Z 127.0.0.1:62104 => {
  ADDRESS: 'xxx.yyy.196.213',
  PORT: 4444,
  UPSTREAM: { host: '443', port: 80, protocol: 'httpbin.org' }
```