### PR TITLE
Handle colons in urls

### DIFF
--- a/core/Session.js
+++ b/core/Session.js
@@ -159,7 +159,7 @@ class Session extends Object {
                     .on(ERROR, onClose)
             );
 
-            this.setRequestSocket(new tls.TLSSocket(this._dst, {
+            const dstSocket = new tls.TLSSocket(this._dst, {
                     rejectUnauthorized: false,
                     requestCert: false,
                     isServer: false
@@ -167,7 +167,10 @@ class Session extends Object {
                     .on(DATA, onDataFromUpstream)
                     .on(CLOSE, onClose)
                     .on(ERROR, onClose)
-            );
+            // https://github.com/nodejs/node/blob/7f7a899fa5f3b192d4f503f6602f24f7ff4ec57a/lib/_tls_wrap.js#L976
+            // https://github.com/nodejs/node/blob/7f7a899fa5f3b192d4f503f6602f24f7ff4ec57a/lib/_tls_wrap.js#L1675-L1686
+            dstSocket.setServername(this._dst._host);
+            this.setRequestSocket(dstSocket);
             this._updated = true;
         }
         return this;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -48,11 +48,13 @@ module.exports = {
         SEPARATOR: ':',
         PROXY_AUTH: 'Proxy-Authorization',
         PROXY_AUTH_BASIC: 'Basic',
+        PLACEHOLDER_PROTOCOL: 'undefined:'
 
     },
     SLASH: '/',
     SLASH_REGEXP: /\//gmi,
     SLASH_REGEXP_ONCE: /\//g,
+    PROTOCOL_REGEXP: /^https?:\/\//i,
     DEFAULT_KEYS: {
         key: '-----BEGIN PRIVATE KEY-----\n' +
             'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgFy3kvv0iHTVaeqcv\n' +


### PR DESCRIPTION
Splitting ipStringWithPort was breaking on http requests when there was
a colon elsewhere in the url. ex: Chrome's update mechanism hitting http://update.googleapis.com/service/update2/json?cup2key=12:XXXXXX