### PR TITLE
chore/refactor test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+
+const config = {
+  testRegex: "test\/.+\.(test|spec)\\.js$",
+  testEnvironment: 'node',
+  globalSetup: "./test/setup.js",
+  globalTeardown: "./test/teardown.js",
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Real transparent HTTP-Proxy-Server. Upstream your requests whatever you want!",
   "main": "ProxyServer.js",
   "scripts": {
-    "test": "node test.js exit 0",
+    "test:e2e": "node test.js exit 0",
+    "test": "jest",
     "prepublish": "npm test"
   },
   "keywords": [
@@ -24,6 +25,9 @@
   "license": "ISC",
   "homepage": "https://github.com/gr3p1p3/transparent-proxy",
   "devDependencies": {
+    "express": "^4.18.2",
+    "http-proxy-agent": "^5.0.0",
+    "jest": "^29.4.1",
     "node-forge": "^1.3.1"
   }
 }

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -1,0 +1,12 @@
+const { startProxy, proxyRequest, stopProxy } = require("./util");
+
+describe("HTTP Proxy", () => {
+  it("should forward headers", async () => {
+    const server = await startProxy(8888, { verbose: true }, () => {
+      console.log("Started Proxy");
+    });
+    const result = await proxyRequest({ "x-baz": "qux" });
+    expect(result.headers["x-baz"]).toBe("qux");
+    await stopProxy(server, () => console.log("Stopped Proxy"));
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,24 @@
+const express = require("express");
+const port = process.env.TP_MOCK_PORT || 9876;
+
+module.exports = async () =>
+  new Promise((resolve) => {
+    const app = express();
+    app.get("*", (req, res) =>
+      res.status(200).send({
+        method: req.method,
+        protocol: req.protocol,
+        version: req.httpVersion,
+        host: req.hostname,
+        headers: req.headers,
+        path: req.path,
+        query: req.query,
+        body: req.body,
+      })
+    );
+    const server = app.listen(port, () => {
+      console.log(`Mock server started on ${port}`);
+      resolve();
+    });
+    globalThis.__MOCK_HTTP_API__ = server;
+  });

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -1,0 +1,7 @@
+module.exports = async () =>
+  new Promise((resolve) => {
+    globalThis.__MOCK_HTTP_API__.close(() => {
+      console.log("Stopped Mock API");
+      resolve();
+    });
+  });

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,96 @@
+const http = require("http");
+const url = require("url");
+
+const HttpProxyAgent = require("http-proxy-agent");
+const ProxyServer = require("../ProxyServer");
+
+const apiPort = process.env.TP_MOCK_PORT || 9876;
+const proxyPort = process.env.TP_PORT || 8888;
+const proxyAgent = new HttpProxyAgent(`http://localhost:${proxyPort}`);
+
+/**
+ * Used in tests to make requests against a mock http server.
+ * The request always returns an object containing details about the received
+ * request for inspection/assertions.
+ * 
+ * @see setup.js
+ * 
+ * @param { Record<string, string> } headers 
+ * @param { string? } path 
+ * @returns { Promise<{
+                method: string,
+                protocol: string,
+                version: string,
+                host: string,
+                headers: Record<{string, string}>,
+                path: string,
+                query: string,
+                body: string
+      }> }
+ */
+const proxyRequest = async (headers, path) =>
+  new Promise((resolve, reject) => {
+    try {
+      http.get(
+        {
+          ...url.parse(`http://localhost:${apiPort}/${path}`),
+          agent: proxyAgent,
+          headers,
+        },
+        (response) => {
+          let data = Buffer.from([]);
+          response.on("data", (chunk) => (data = Buffer.concat([data, chunk])));
+          response.on("end", () => resolve(JSON.parse(data?.toString())));
+          response.on("error", (err) => reject(err));
+        }
+      );
+    } catch (err) {
+      reject(err);
+    }
+  });
+
+/**
+ *
+ * @param {int} port
+ * @param {ProxyServer Options} options
+ * @param {callback} onStarted
+ * @returns {Promise<ProxyServer>}
+ */
+const startProxy = (port, options = {}, onStarted) =>
+  new Promise((resolve, reject) => {
+    try {
+      const proxy = new ProxyServer(options);
+      const server = proxy.listen(port, () => {
+        onStarted && onStarted();
+        resolve(server);
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+
+/**
+ * Closes the given server and executes the (optional) callback when done.
+ *
+ * @param {ProxyServer} server
+ * @param {function?} callback
+ * @returns void
+ */
+const stopProxy = (server, callback) => {
+  return new Promise((resolve, reject) => {
+    try {
+      server?.close(() => {
+        callback && callback();
+        resolve();
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+};
+
+module.exports = {
+  proxyRequest,
+  startProxy,
+  stopProxy,
+};


### PR DESCRIPTION
Implements/refactors existing tests on top of jest + a local express app to inspect traffic after the proxy did its thing.

Refer to [this discussion](https://github.com/gr3p1p3/transparent-proxy/discussions/29) for details.

