### PR TITLE
fix: Don't crash if no response headers are sent

### DIFF
--- a/lib/parseDataToObject.js
+++ b/lib/parseDataToObject.js
@@ -13,7 +13,9 @@ module.exports = function parseDataToObject(data, isResponse = false, chunked = 
     const DOUBLE_CRLF = CRLF + CRLF;
     const dataString = data.toString();
     const splitAt = dataString.indexOf(DOUBLE_CRLF); //TODO split at LF and delete CR after instead doing this
-    const infoObject = {};
+    const infoObject = {
+        headers: {}
+    };
 
     if (!chunked) {
         let [headers, body] = [dataString.slice(0, splitAt), dataString.slice(splitAt + DOUBLE_CRLF.length)];
@@ -38,7 +40,6 @@ module.exports = function parseDataToObject(data, isResponse = false, chunked = 
                 }
             }
             else {
-                infoObject.headers = infoObject.headers || {};
                 const splitIndexRow = headerRow.indexOf(SEPARATOR);
                 const [attribute, value] = [headerRow.slice(0, splitIndexRow), headerRow.slice(splitIndexRow + 1)];
                 if (attribute && value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transparent-proxy",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Real transparent HTTP-Proxy-Server. Upstream your requests whatever you want!",
   "main": "ProxyServer.js",
   "scripts": {


### PR DESCRIPTION
Closes #33 

Implements the second fix described in the issue.